### PR TITLE
Make VAT fields customizable

### DIFF
--- a/includes/generation.php
+++ b/includes/generation.php
@@ -222,7 +222,17 @@ class WcEenvoudigFactureren_Generation {
         }
 
         // try looking for a vat number
-        foreach(['_vat_number', '_billing_vat_number', 'vat_number', '_billing_vat', '_billing_eu_vat_number', '_billing_btw_nummer'] as $meta) {
+        $meta_keys = apply_filters('wc_eenvfact_vat_keys', [
+            '_vat_number',
+            '_billing_vat_number',
+            'vat_number',
+            '_billing_vat',
+            '_billing_eu_vat_number',
+            '_billing_btw_nummer',
+            'yweu_billing_vat'
+        ]);
+
+        foreach($meta_keys as $meta) {
             $vat_number = $order->get_meta( $meta, true );
             if ($vat_number) {
                 break;


### PR DESCRIPTION
I wrapped the VAT meta_keys array in a Wordpress filter. This way everyone can define their own VAT custom field to check for. This adds more flexibility in the VAT plugins that are supported.

F.e. you can add your own custom field like this

```
add_filter('wc_eenvfact_vat_keys', function($meta_keys) {
    $meta_keys[] = 'b2bking_custom_field_28';
    return $meta_keys;
});
```
I also added the "yweu_billing_vat" into the array to support the "YITH Woocommerce EU VAT, OSS & IOSS Premium" plugin.