### PR TITLE
Allow skipping of invoice when certain conditions are met

### DIFF
--- a/includes/generation.php
+++ b/includes/generation.php
@@ -54,7 +54,15 @@ class WcEenvoudigFactureren_Generation {
             return;
         }
 
-        if( ! get_post_meta( $order_id, WC_EENVFACT_OPTION_PREFIX . 'document_generated', true ) && ! get_post_meta( $order_id, WC_EENVFACT_OPTION_PREFIX . 'document_generating', true ) ) {
+        // Allow skipping of invoice generation
+        // Skip when document is already generating or generated
+        $should_skip = apply_filters('wc_eenvfact_should_skip_generation',
+            get_post_meta($order_id, WC_EENVFACT_OPTION_PREFIX . 'document_generated', true) || 
+            get_post_meta($order_id, WC_EENVFACT_OPTION_PREFIX . 'document_generating', true), 
+            $order_id
+        );
+
+        if(!$should_skip) {
             $order = wc_get_order( $order_id );
 
             $order->update_meta_data( WC_EENVFACT_OPTION_PREFIX . 'document_generating', true );


### PR DESCRIPTION
I added a Wordpress filter that allows users to add additional conditions that need to be met before starting the invoice generation.

I needed this because we also sell products in the marketplace of Bol.com. These orders also get imported in our Woocommerce instance so we can handle them centrally and manage stock globally, but the actual invoice is already created in the Bol admin interface. So these particular invoices don't need to be generated again in EenvoudigFactureren.

You can then achieve this kind of behavior by adding a filter in your functions.php like so.

```php
// Don't create an invoice for bol orders
add_filter('wc_eenvfact_should_skip_generation', function($should_skip, $order_id) {
    if (get_post_meta($order_id, '_payment_method', true) === 'bol') {
        return true; // Skip if payment method is 'bol'
    }
    
    return $should_skip;
}, 10, 2);