### PR TITLE
Add support for WPML, add language parameter to document

### DIFF
--- a/eenvoudigfactureren-for-woocommerce.php
+++ b/eenvoudigfactureren-for-woocommerce.php
@@ -6,7 +6,7 @@
  * Author: EenvoudigFactureren
  * Author URI: https://eenvoudigfactureren.be
  * Text Domain: eenvoudigfactureren-for-woocommerce
- * Version: 1.0.17
+ * Version: 1.0.18
  * Requires at least: 5.2.0
  * Requires PHP: 5.6.20
  * Domain Path: /languages

--- a/includes/generation.php
+++ b/includes/generation.php
@@ -301,7 +301,11 @@ class WcEenvoudigFactureren_Generation {
     private function build_document($order, $client_id, &$error) {
         $document = array();
         $document['client_id'] = $client_id;
-        $document['language'] = $this->get_order_language($order);
+
+        $language = $this->get_order_language($order);
+        if ($language) {
+            $document['language'] = $language;
+        }
 
         $layout_id = $this->options->get('layout_id');
         if ($layout_id) {
@@ -450,7 +454,6 @@ class WcEenvoudigFactureren_Generation {
             }
         }
 
-        // Return a fallback language
-        return $locales['nl'];
+        return false;
     }
 }

--- a/includes/generation.php
+++ b/includes/generation.php
@@ -20,7 +20,6 @@ class WcEenvoudigFactureren_Generation {
     }
 
     public function triggered_new_order( $order_id ) {
-
         // if is vat exempt find exempt reason in 'Zero rate' tarifs
         // needs to be executed here because customer is only available at checkout
         if ($order_id && get_post_meta( $order_id, 'is_vat_exempt', true ) == 'yes') {
@@ -96,6 +95,7 @@ class WcEenvoudigFactureren_Generation {
             if ($this->options->get('document_type') == 'receipt') {
                 $domain = 'receipts';
             }
+
 
             $create_result = $this->client->post($domain, $document, $error);
 
@@ -299,9 +299,9 @@ class WcEenvoudigFactureren_Generation {
     }
 
     private function build_document($order, $client_id, &$error) {
-
         $document = array();
         $document['client_id'] = $client_id;
+        $document['language'] = $this->get_order_language($order);
 
         $layout_id = $this->options->get('layout_id');
         if ($layout_id) {
@@ -407,7 +407,7 @@ class WcEenvoudigFactureren_Generation {
                 'description' => 'WooCommerce',
             ]];
         }
-
+        
         return (object)$document;
     }
 
@@ -416,10 +416,11 @@ class WcEenvoudigFactureren_Generation {
         $meta_keys = apply_filters('wc_eenvfact_vat_keys', [
             '_vat_number',
             '_billing_vat_number',
-            'vat_number',
             '_billing_vat',
             '_billing_eu_vat_number',
             '_billing_btw_nummer',
+            '_billing_yweu_vat',
+            'vat_number',
             'yweu_billing_vat'
         ]);
 
@@ -431,5 +432,25 @@ class WcEenvoudigFactureren_Generation {
         }
         
         return '';
+    }
+
+    private function get_order_language($order) {
+        $meta_keys = ['wpml_language'];
+        $locales = [
+            'nl' => 'dutch',
+            'fr' => 'french',
+            'de' => 'german',
+            'en' => 'english',
+        ];
+    
+        foreach ($meta_keys as $meta) {
+            $code = $order->get_meta($meta, true);
+            if (!empty($code ) && isset( $locales[$code])) {
+                return $locales[$code];
+            }
+        }
+
+        // Return a fallback language
+        return $locales['nl'];
     }
 }


### PR DESCRIPTION
This fixes the issue below.
We have a multilingual Woocommerce store running on the WPML translation plugin.
However every customer gets his/her invoice in Dutch, even if they checked out in English or French.
This update fetches the chosen language and creates the invoice in the correct language. 
If the order has no language metadata, it falls back to the default language of Dutch.